### PR TITLE
Use gliderlabs/alpine:3.1 for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,16 @@
-FROM ubuntu:14.04
+FROM gliderlabs/alpine:3.1
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 
 ENV TERRAFORM_VERSION 0.5.0
 
-RUN apt-get update && \
-    apt-get install -y \
-      libcurl4-openssl-dev \
-      git \
-      unzip \
-      curl && \
-    mkdir -p /tmp/terraform && \
+RUN mkdir -p /tmp/terraform && \
     cd /tmp/terraform && \
-    curl -L https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > \
-      terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    wget http://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+      -O terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     mv terraform* /usr/local/bin/ && \
-    rm -rf /tmp/terraform && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /tmp/terraform
 
 VOLUME ["/terraform"]
 WORKDIR /terraform


### PR DESCRIPTION
## WHAT

Use gliderlabs/alpine:3.1 for base image
- `gliderlabs/alpine:3.1`: 5.029 MB
- `ubuntu:14.04`: 188.3 MB
### Before / After

``` bash
# original
quay.io/wantedly/terraform   latest              bebc9cd9d1f9        2 days ago          628.2 MB

# alpine based
quay.io/wantedly/terraform   latest              119da9885eb9        18 seconds ago      246.5 MB
```
### Detail

``` bash
/terraform # ls -lh /usr/local/bin/
total 235836
-rwxr-xr-x    4 root     root       14.5M May 14 02:39 terraform
-rwxr-xr-x    4 root     root       10.0M May 14 02:39 terraform-provider-atlas
-rwxr-xr-x    4 root     root       17.8M May 14 02:39 terraform-provider-aws
-rwxr-xr-x    4 root     root        9.9M May 14 02:39 terraform-provider-cloudflare
-rwxr-xr-x    4 root     root       19.3M May 14 02:39 terraform-provider-cloudstack
-rwxr-xr-x    4 root     root       10.2M May 14 02:39 terraform-provider-consul
-rwxr-xr-x    4 root     root       10.2M May 14 02:39 terraform-provider-digitalocean
-rwxr-xr-x    4 root     root        9.9M May 14 02:39 terraform-provider-dme
-rwxr-xr-x    4 root     root        9.9M May 14 02:39 terraform-provider-dnsimple
-rwxr-xr-x    4 root     root       10.9M May 14 02:39 terraform-provider-docker
-rwxr-xr-x    4 root     root       12.4M May 14 02:39 terraform-provider-google
-rwxr-xr-x    4 root     root       10.4M May 14 02:39 terraform-provider-heroku
-rwxr-xr-x    4 root     root        9.9M May 14 02:39 terraform-provider-mailgun
-rwxr-xr-x    4 root     root        9.8M May 14 02:39 terraform-provider-null
-rwxr-xr-x    4 root     root       12.3M May 14 02:39 terraform-provider-openstack
-rwxr-xr-x    4 root     root        9.8M May 14 02:39 terraform-provider-template
-rwxr-xr-x    4 root     root       11.6M May 14 02:39 terraform-provider-terraform
-rwxr-xr-x    4 root     root       11.0M May 14 02:39 terraform-provisioner-file
-rwxr-xr-x    4 root     root        9.5M May 14 02:39 terraform-provisioner-local-exec
-rwxr-xr-x    4 root     root       11.0M May 14 02:39 terraform-provisioner-remote-exec
/terraform # ls -lh /usr/local/bin/ | wc -l
21

#=> 10 M * 21 = 210 MB~

/terraform # du -h /usr/local/bin/
230.3M  /usr/local/bin/
```
## WHY

To make terraform image more lightweight
## REF
- [gliderlabs/docker-alpine](https://github.com/gliderlabs/docker-alpine)
- [docker-alpine :: viewdocs.io](http://gliderlabs.viewdocs.io/docker-alpine)
