### PR TITLE
Terraform 0.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-FROM gliderlabs/alpine:3.1
+FROM debian:jessie
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
+CMD ["/usr/local/bin/terraform", "version"]
 
-ENV TERRAFORM_VERSION 0.5.0
+ENV TERRAFORM_VERSION 0.5.3
 
-RUN apk --update add ca-certificates && \
-    mkdir -p /tmp/terraform && \
-    cd /tmp/terraform && \
-    wget http://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-      -O terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    mv terraform* /usr/local/bin/ && \
-    rm -rf /tmp/terraform
+RUN apt-get update \
+    && apt-get install -y \
+      libcurl4-openssl-dev \
+      unzip \
+      curl \
+    && mkdir -p /tmp/terraform \
+    && cd /tmp/terraform \
+    && curl -L https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > \
+      terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && mv terraform* /usr/local/bin/ \
+    && rm -rf /tmp/terraform \
+    && apt-get purge -y curl unzip
 
 VOLUME ["/terraform"]
 WORKDIR /terraform
-
-CMD ["terraform", "version"]

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORM_VERSION="0.5.0"
+TERRAFORM_VERSION="0.5.3"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHAT
- Use terraform 0.5.3
- Change base image from `alpine:linux` to `debian:jessie` to fix https://github.com/wantedly/dockerfile-terraform/pull/11
  - Image size: 408.5MB
## WHY

We want to use some new supports:
- S3 bucket policy
- Network ACL association with multiple subnet
- etc...
