### PR TITLE
Upgrade to Terraform v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 CMD ["/usr/local/bin/terraform", "version"]
 
-ENV TERRAFORM_VERSION 0.5.3
+ENV TERRAFORM_VERSION 0.6.0
 
 RUN apt-get update \
     && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see [official document](https://terraform.io/docs/index.html) for more in
 ## SUPPORTED TAGS
 
 * `latest`
- * Terraform 0.5.3
+ * Terraform 0.6.0
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORM_VERSION="0.5.3"
+TERRAFORM_VERSION="0.6.0"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHAT

Use Terraform v0.6.0
## WHY

We want to use some new supports:
- [aws_iam_group_membership](https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html)
- etc...
## REF
- [terraform/CHANGELOG.md at master · hashicorp/terraform](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#060-june-30-2015)
