### PR TITLE
Upgrade to Terraform v0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
 CMD ["/usr/local/bin/terraform", "version"]
 
-ENV TERRAFORM_VERSION 0.6.0
+ENV TERRAFORM_VERSION 0.6.1
 
 RUN apt-get update \
     && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see [official document](https://terraform.io/docs/index.html) for more in
 ## SUPPORTED TAGS
 
 * `latest`
- * Terraform 0.6.0
+ * Terraform 0.6.1
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORM_VERSION="0.6.0"
+TERRAFORM_VERSION="0.6.1"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHAT

Use Terraform v0.6.1 
## WHY

Terraform v0.6.1 have some improvements, e.g. fix a bug of `terraform plan` result ([hashicorp/terraform#2620](https://github.com/hashicorp/terraform/pull/2620)).
## REF
- [terraform/CHANGELOG.md at master · hashicorp/terraform](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#061-july-20-2015)
