### PR TITLE
Upgrade to Terraform v0.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,14 @@
-FROM debian:jessie
-MAINTAINER Daisuke Fujita <dtanshi45@gmail.com> (@dtan4)
-CMD ["/usr/local/bin/terraform", "version"]
+FROM alpine:3.2
 
 ENV TERRAFORM_VERSION 0.6.1
 
-RUN apt-get update \
-    && apt-get install -y \
-      libcurl4-openssl-dev \
-      unzip \
-      curl \
-    && mkdir -p /tmp/terraform \
-    && cd /tmp/terraform \
-    && curl -L https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > \
-      terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-    && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-    && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-    && mv terraform* /usr/local/bin/ \
-    && rm -rf /tmp/terraform \
-    && apt-get purge -y curl unzip
+RUN apk add --update wget ca-certificates unzip && \
+    wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
+    apk add --allow-untrusted glibc-2.21-r2.apk && \
+    wget -q -O /terraform.zip "https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    unzip /terraform.zip -d /bin && \
+    apk del --purge wget ca-certificates unzip && \
+    rm -rf /var/cache/apk/* glibc-2.21-r2.apk /terraform.zip
 
 VOLUME ["/terraform"]
 WORKDIR /terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.2
 
-ENV TERRAFORM_VERSION 0.6.1
+ENV TERRAFORM_VERSION 0.6.6
 
 RUN apk add --update wget ca-certificates unzip && \
     wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see [official document](https://terraform.io/docs/index.html) for more in
 ## SUPPORTED TAGS
 
 * `latest`
- * Terraform 0.6.1
+ * Terraform 0.6.6
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -6,7 +6,7 @@
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORM_VERSION="0.6.1"
+TERRAFORM_VERSION="0.6.6"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHY

To use `lifecycle` feature which was [introduced at v0.6.4](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#064-october-15-2015)
## WHAT

Use Terraform v0.6.6, and use alpine image to reduce entire image size.
## REF
- [terraform/CHANGELOG.md at master · hashicorp/terraform](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#066-october-23-2015)
