### PR TITLE
Move to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+services:
+  - docker
+before_install:
+  - docker -v
+script:
+  - script/test
+notifications:
+  slack:
+    secure: AXSkMBWQkXMP0MsrCxIO/v9KT+vh3BvSFaooRNRmt7mAjSHMxuR+Mhtgx89DvIQtOumIloVh9gGRPIMdp9I/annmi8mpdtSXFIv5CQuhW5nEGrSZKauRIwTJJb3wktOoWaJ1r8dM0ItBWyYZKprETA7PhSrUZ2mSdiCgTZBtksE=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Terraform Docker Image [![Docker Repository on Quay.io](https://quay.io/repository/wantedly/terraform/status "Docker Repository on Quay.io")](https://quay.io/repository/wantedly/terraform)
+# Terraform Docker Image
+[![Build Status](https://travis-ci.org/wantedly/dockerfile-terraform.svg?branch=master)](https://travis-ci.org/wantedly/dockerfile-terraform)
+[![Docker Repository on Quay.io](https://quay.io/repository/wantedly/terraform/status "Docker Repository on Quay.io")](https://quay.io/repository/wantedly/terraform)
+
 Docker Image for [Terraform](https://terraform.io).
 Please see [official document](https://terraform.io/docs/index.html) for more information about Terraform.
 


### PR DESCRIPTION
## WHY

The version of Docker running on wercker is 1.2.0. Docker Hub announced that [Docker 1.5 and earlier are deprecated at 2015-12-07](https://blog.docker.com/2015/10/docker-hub-deprecation-1-5/).
## WHAT

Move CI service to Travis CI.
