### PR TITLE
Upgrade terraform 0.6.6 to 0.6.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.2
 
-ENV TERRAFORM_VERSION 0.6.6
+ENV TERRAFORM_VERSION 0.6.14
 
 RUN apk add --update wget ca-certificates unzip && \
     wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \


### PR DESCRIPTION
## WHY

Upgrade terraform 0.6.6 to 0.6.14
