### PR TITLE
Upgrade to Terraform v0.6.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM alpine:3.2
+FROM alpine:3.4
 
 ENV TERRAFORM_VERSION 0.6.14
+ENV GLIBC_VERSION 2.23-r3
 
-RUN apk add --update wget ca-certificates unzip && \
-    wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
-    apk add --allow-untrusted glibc-2.21-r2.apk && \
-    wget -q -O /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+RUN apk add --no-cache --update ca-certificates unzip wget && \
+    wget -qO /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+    apk add --no-cache glibc-${GLIBC_VERSION}.apk && \
+    wget -qO /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip /terraform.zip -d /bin && \
-    apk del --purge wget ca-certificates unzip && \
-    rm -rf /var/cache/apk/* glibc-2.21-r2.apk /terraform.zip
+    apk del --purge ca-certificates unzip wget && \
+    rm -rf glibc-${GLIBC_VERSION}.apk /terraform.zip
 
 VOLUME ["/terraform"]
 WORKDIR /terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM alpine:3.4
 ENV TERRAFORM_VERSION 0.6.14
 ENV GLIBC_VERSION 2.23-r3
 
-RUN apk add --no-cache --update ca-certificates unzip wget && \
-    wget -qO /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
-    apk add --no-cache glibc-${GLIBC_VERSION}.apk && \
-    wget -qO /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
-    unzip /terraform.zip -d /bin && \
-    apk del --purge ca-certificates unzip wget && \
-    rm -rf glibc-${GLIBC_VERSION}.apk /terraform.zip
+RUN apk add --no-cache --update ca-certificates unzip wget \
+    && wget -qO /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    && apk add --no-cache glibc-${GLIBC_VERSION}.apk \
+    && wget -qO /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
+    && unzip /terraform.zip -d /bin \
+    && apk del --purge ca-certificates unzip wget \
+    && rm -rf glibc-${GLIBC_VERSION}.apk /terraform.zip
 
 VOLUME ["/terraform"]
 WORKDIR /terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV TERRAFORM_VERSION 0.6.14
+ENV TERRAFORM_VERSION 0.6.16
 ENV GLIBC_VERSION 2.23-r3
 
 RUN apk add --no-cache --update ca-certificates unzip wget \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see [official document](https://terraform.io/docs/index.html) for more in
 ## SUPPORTED TAGS
 
 * `latest`
- * Terraform 0.6.6
+ * Terraform 0.6.16
 
 ## HOW TO USE
 

--- a/script/test
+++ b/script/test
@@ -8,7 +8,7 @@ set -e
 
 # this script should be run in project root
 BASE_DIRECTORY=`pwd`
-TERRAFORM_VERSION="0.6.14"
+TERRAFORM_VERSION="0.6.16"
 
 echo "==> Building target..."
 cd ${BASE_DIRECTORY}


### PR DESCRIPTION
## WHY

We would like to use [aws_cloudfront_distribution](https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html) resource, which was introduced from v0.6.15. Currently we use v0.6.14.
## WHAT

Upgrade Terraform version to the latest v0.6.16.
