### PR TITLE
Remain ca-certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache --update ca-certificates unzip wget \
     && apk add --no-cache glibc-${GLIBC_VERSION}.apk \
     && wget -qO /terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
     && unzip /terraform.zip -d /bin \
-    && apk del --purge ca-certificates unzip wget \
+    && apk del --purge unzip wget \
     && rm -rf glibc-${GLIBC_VERSION}.apk /terraform.zip
 
 VOLUME ["/terraform"]


### PR DESCRIPTION
## WHY

`terraform pull` from S3 fails with the error below.

```
Error while performing the initial pull. The error message is shown
below. Note that remote state was properly configured, so you don't
need to reconfigure. You can now use `push` and `pull` directly.

Error reloading remote state: RequestError: send request failed
caused by: Get https://bucket.s3-ap-northeast-1.amazonaws.com/tf: x509: failed to load system roots and no roots provided
```
## WHAT

Do not remove `ca-certificate` package
